### PR TITLE
execute-apv: Drop python2

### DIFF
--- a/.github/workflows/execute-apv.yaml
+++ b/.github/workflows/execute-apv.yaml
@@ -8,11 +8,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install python2 dependencies
-      run: pip2 install --user protobuf
-
     - name: Install python3 dependencies
-      run: sudo apt-get -y install python3-setuptools && pip3 install --user pyyaml gitpython
+      run: sudo apt-get -y install python3-setuptools && pip3 install --user pyyaml gitpython protobuf
 
     - name: Run android-prepare-vendor for each device
       run: python3 execute_apv.py --metadata --threads 2


### PR DESCRIPTION
Both extract_android_ota_payload and carriersettings_extractor use python3 now